### PR TITLE
making RULES.md links generate html links

### DIFF
--- a/gensite.js
+++ b/gensite.js
@@ -87,4 +87,4 @@ sh.cp('-f', join(demoPath, 'bundle.js'), resolve(__dirname, 'dist', 'standard-de
 sh.cp('-R', 'favicons', resolve(__dirname, 'dist'))
 
 // remove tmp dir
-// sh.rm('-rf', 'tmp')
+sh.rm('-rf', 'tmp')

--- a/gensite.js
+++ b/gensite.js
@@ -30,7 +30,7 @@ if (!sh.which('git')) {
   sh.exit(1)
 }
 
-pullOrClone('https://github.com/standard/standard', stdPath)
+pullOrClone('https://github.com/helloitsjoe/standard', stdPath)
 pullOrClone('https://github.com/standard/awesome-standard', awesomePath)
 pullOrClone('https://github.com/flet/standard-demo', demoPath)
 
@@ -66,6 +66,7 @@ sh.find(buildPath)
 .forEach(function (f) {
   // replace all RULES.md instances in links with rules.html
   sh.sed('-i', /"(docs\/|\.\.\/)?RULES(.*?)\.md/g, '"rules$2.html', f)
+  // sh.sed('-i', /"(.*?)RULES(.*?)\.md/g, '"rules$2.html', f)
 
   sh.sed('-i', /"\.\.\/README.md/g, '"index.html', f)
   sh.sed('-i', /"(.*?)README(.*?)\.md/g, '"readme$2.html', f)
@@ -85,3 +86,6 @@ sh.cp('-f', join(demoPath, 'bundle.js'), resolve(__dirname, 'dist', 'standard-de
 
 // copy favicons to dist
 sh.cp('-R', 'favicons', resolve(__dirname, 'dist'))
+
+// remove tmp dir
+// sh.rm('-rf', 'tmp')

--- a/gensite.js
+++ b/gensite.js
@@ -30,7 +30,7 @@ if (!sh.which('git')) {
   sh.exit(1)
 }
 
-pullOrClone('https://github.com/helloitsjoe/standard', stdPath)
+pullOrClone('https://github.com/standard/standard', stdPath)
 pullOrClone('https://github.com/standard/awesome-standard', awesomePath)
 pullOrClone('https://github.com/flet/standard-demo', demoPath)
 
@@ -65,8 +65,7 @@ sh.find(buildPath)
 .filter(function (file) { return file.match(/\.html$/) })
 .forEach(function (f) {
   // replace all RULES.md instances in links with rules.html
-  sh.sed('-i', /"(docs\/|\.\.\/)?RULES(.*?)\.md/g, '"rules$2.html', f)
-  // sh.sed('-i', /"(.*?)RULES(.*?)\.md/g, '"rules$2.html', f)
+  sh.sed('-i', /"(.*?)RULES(.*?)\.md/g, '"rules$2.html', f)
 
   sh.sed('-i', /"\.\.\/README.md/g, '"index.html', f)
   sh.sed('-i', /"(.*?)README(.*?)\.md/g, '"readme$2.html', f)


### PR DESCRIPTION
### FIXING
* Making RULES.md files generate rules.html links
  * This fixes the change introduced by [[standard PR#1005](https://github.com/standard/standard/pull/1005)], but it doesn’t break anything, so it’s not dependent on 1005 being merged first.
* Removing tmp directory as last step of gensite.js
  * If `tmp` directory exists when gensite runs, it doesn’t get overwritten)