### PR TITLE
fix(security): update ecstatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "browserify": "^14.0.0",
     "catw": "^1.0.1",
-    "ecstatic": "^1.4.0",
+    "ecstatic": "^3.1.1",
     "less": "^2.6.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Bumping ecstatic to resolve a security vulnerability flagged by github.

https://nvd.nist.gov/vuln/detail/CVE-2016-10703